### PR TITLE
Github actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Upload build
         uses: actions/upload-artifact@v3
         with:
-          name: latest-dev.jar
+          name: latest-dev
           path: build/libs/coffee-1.0.0.jar


### PR DESCRIPTION
filename from github actions download is "latest-dev.jar.zip", this changes it to "latest-dev.zip" which is sexier